### PR TITLE
Use `OffscreenCanvas` Interface

### DIFF
--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -57,10 +57,17 @@ class CrewCertificateRenderer {
 
   // Public Methods
   /** @param { CrewCertificate } model */
-  /** @param { HTMLCanvasElement } canvas */
-  async generateCardFront(model, canvas) {
-    canvas.setAttribute("width", this.constructor.#cardArea[0]);
-    canvas.setAttribute("height", this.constructor.#cardArea[1]);
+  /** @param { HTMLCanvasElement } fallback */
+  async generateCardFront(model, fallback) {
+    let canvas;
+    if (typeof OffscreenCanvas === "undefined") {
+      canvas = fallback;
+      canvas.setAttribute("width", this.constructor.#cardArea[0]);
+      canvas.setAttribute("height", this.constructor.#cardArea[1]);
+    }
+    else {
+      canvas = new OffscreenCanvas( this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
+    }
     const ctx = canvas.getContext("2d");
     ctx.textBaseline = "top";
 
@@ -332,13 +339,22 @@ class CrewCertificateRenderer {
     if (this.showGuides) {
       this.constructor.#drawBleedAndSafeLines(ctx);
     }
+
+    return canvas;
   }
 
   /** @param { CrewCertificate } model */
   /** @param { HTMLCanvasElement } canvas */
-  async generateCardBack(model, canvas) {
-    canvas.setAttribute("width", this.constructor.#cardArea[0]);
-    canvas.setAttribute("height", this.constructor.#cardArea[1]);
+  async generateCardBack(model, fallback) {
+    let canvas;
+    if (typeof OffscreenCanvas === "undefined") {
+      canvas = fallback;
+      canvas.setAttribute("width", this.constructor.#cardArea[0]);
+      canvas.setAttribute("height", this.constructor.#cardArea[1]);
+    }
+    else {
+      canvas = new OffscreenCanvas( this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
+    }
     const ctx = canvas.getContext("2d");
     ctx.textBaseline = "top";
 
@@ -516,6 +532,8 @@ class CrewCertificateRenderer {
     if (this.showGuides) {
       this.constructor.#drawBleedAndSafeLines(ctx);
     }
+
+    return canvas;
   }
 
   async loadCanvasFonts() {
@@ -752,7 +770,7 @@ class CrewCertificateRenderer {
   static async generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
-    if (typeof OffscreenCanvas === 'undefined') {
+    if (typeof OffscreenCanvas === "undefined") {
       canvas = canvasFallback;
       canvas.setAttribute("width", this.#signatureArea[0]);
       canvas.setAttribute("height", this.#signatureArea[1]);

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -66,7 +66,7 @@ class CrewCertificateRenderer {
       canvas.setAttribute("height", this.constructor.#cardArea[1]);
     }
     else {
-      canvas = new OffscreenCanvas( this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
+      canvas = new OffscreenCanvas(this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
     }
     const ctx = canvas.getContext("2d");
     ctx.textBaseline = "top";
@@ -344,7 +344,7 @@ class CrewCertificateRenderer {
   }
 
   /** @param { CrewCertificate } model */
-  /** @param { HTMLCanvasElement } canvas */
+  /** @param { HTMLCanvasElement } fallback */
   async generateCardBack(model, fallback) {
     let canvas;
     if (typeof OffscreenCanvas === "undefined") {
@@ -353,7 +353,7 @@ class CrewCertificateRenderer {
       canvas.setAttribute("height", this.constructor.#cardArea[1]);
     }
     else {
-      canvas = new OffscreenCanvas( this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
+      canvas = new OffscreenCanvas(this.constructor.#cardArea[0], this.constructor.#cardArea[1]);
     }
     const ctx = canvas.getContext("2d");
     ctx.textBaseline = "top";
@@ -775,12 +775,11 @@ class CrewCertificateRenderer {
       canvas = canvasFallback;
       canvas.setAttribute("width", this.#signatureArea[0]);
       canvas.setAttribute("height", this.#signatureArea[1]);
-      ctx = canvas.getContext("2d");
     }
     else {
-      canvas = new OffscreenCanvas( this.#signatureArea[0], this.#signatureArea[1]);
-      ctx = canvas.getContext("2d");
+      canvas = new OffscreenCanvas(this.#signatureArea[0], this.#signatureArea[1]);
     }
+    ctx = canvas.getContext("2d");
     ctx.fillStyle = this.textColor;
     ctx.font = this.#signatureFont;
     ctx.textBaseline = "top";

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -656,6 +656,7 @@ class CrewCertificateRenderer {
 
   // Areas used in card generation (static)
   static #cardArea = [1052, 672];
+  static cutCardArea = [1020, 640];
   static #photoUnderlayArea = [402, 527];
   static #photoArea = [370, 370];
   static #logoUnderlayArea = [434, 93];

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -732,7 +732,25 @@ class CrewCertificateRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
-  
+  static async* generateNewSignatureFromText(canvasFallback) {
+    let oldSignature = "";
+    let signature = "";
+    let canvas;
+
+    while (true) {
+      signature = yield;
+      console.log(`Old Signature: ${oldSignature}`);
+      console.log(`New Signature: ${signature}`);
+      if (oldSignature === signature) {
+        yield { newSignature: false, signature: canvas };
+      }
+      else {
+        oldSignature = signature;
+        canvas = await this.generateSignatureFromText(signature, canvasFallback);
+        yield { newSignature: true, signature: canvas };
+      }
+    }
+  }
   static async generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -739,8 +739,6 @@ class CrewCertificateRenderer {
 
     while (true) {
       signature = yield;
-      console.log(`Old Signature: ${oldSignature}`);
-      console.log(`New Signature: ${signature}`);
       if (oldSignature === signature) {
         yield { newSignature: false, signature: canvas };
       }

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -751,7 +751,7 @@ class CrewCertificateRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
-  static async* generateNewSignatureFromText(canvasFallback) {
+  static * generateNewSignatureFromText(canvasFallback) {
     let oldSignature = "";
     let signature = "";
     let canvas;
@@ -763,12 +763,12 @@ class CrewCertificateRenderer {
       }
       else {
         oldSignature = signature;
-        canvas = await this.generateSignatureFromText(signature, canvasFallback);
+        canvas = this.#generateSignatureFromText(signature, canvasFallback);
         yield { newSignature: true, signature: canvas };
       }
     }
   }
-  static async generateSignatureFromText(signature, canvasFallback) {
+  static #generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
     if (typeof OffscreenCanvas === "undefined") {

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -1401,7 +1401,7 @@ class CrewCertificateViewModel {
     const canvas = await this.#renderer.generateCardFront(this.#model, this.#frontFallback);
     this.#cardFrontElement.width = CrewCertificateRenderer.cutCardArea[0];
     this.#cardFrontElement.height = CrewCertificateRenderer.cutCardArea[1];
-    ctx = this.#cardFrontElement.getContext("2d");
+    const ctx = this.#cardFrontElement.getContext("2d");
     ctx.drawImage(
       canvas, 16, 16, this.#cardFrontElement.width, this.#cardFrontElement.height,
       0, 0, this.#cardFrontElement.width, this.#cardFrontElement.height
@@ -1413,7 +1413,7 @@ class CrewCertificateViewModel {
     const canvas = await this.#renderer.generateCardBack(this.#model, this.#backFallback);
     this.#cardBackElement.width = CrewCertificateRenderer.cutCardArea[0];
     this.#cardBackElement.height = CrewCertificateRenderer.cutCardArea[1];
-    ctx = this.#cardBackElement.getContext("2d");
+    const ctx = this.#cardBackElement.getContext("2d");
     ctx.drawImage(
       canvas, 16, 16, this.#cardBackElement.width, this.#cardBackElement.height,
       0, 0, this.#cardBackElement.width, this.#cardBackElement.height

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -1406,7 +1406,7 @@ class CrewCertificateViewModel {
       canvas, 16, 16, this.#cardFrontElement.width, this.#cardFrontElement.height,
       0, 0, this.#cardFrontElement.width, this.#cardFrontElement.height
     );
-    this.#generateDownloadFrontLink();
+    await this.#generateDownloadFrontLink(canvas);
   }
 
   async #generateCardBack() {
@@ -1418,7 +1418,7 @@ class CrewCertificateViewModel {
       canvas, 16, 16, this.#cardBackElement.width, this.#cardBackElement.height,
       0, 0, this.#cardBackElement.width, this.#cardBackElement.height
     );
-    this.#generateDownloadBackLink();
+    await this.#generateDownloadBackLink(canvas);
   }
 
   async #generateCard() {
@@ -1428,24 +1428,38 @@ class CrewCertificateViewModel {
     ]);
   }
 
-  #generateDownloadFrontLink() {
+  async #generateDownloadFrontLink(canvas) {
     const downloadFront = this.#document.getElementById("downloadFront");
+    let blob;
+    if (typeof OffscreenCanvas === "undefined") {
+      blob = await new Promise(resolve => canvas.toBlob(resolve));
+    }
+    else { blob = await canvas.convertToBlob(); }
+    if (this.#frontBlobURL !== null) { URL.revokeObjectURL(this.#frontBlobURL); }
+    this.#frontBlobURL = URL.createObjectURL(blob);
     downloadFront.setAttribute(
       "download",
       `${this.#model.typeCodeVIZ}${this.#model.authorityCodeVIZ}` +
       `${this.#model.numberVIZ}-front.png`
     );
-    downloadFront.setAttribute("href", this.#cardFrontElement.toDataURL("image/png"));
+    downloadFront.setAttribute("href", this.#frontBlobURL);
   }
 
-  #generateDownloadBackLink() {
+  async #generateDownloadBackLink(canvas) {
     const downloadBack = this.#document.getElementById("downloadBack");
+    let blob;
+    if (typeof OffscreenCanvas === "undefined") {
+      blob = await new Promise(resolve => canvas.toBlob(resolve));
+    }
+    else { blob = await canvas.convertToBlob(); }
+    if (this.#backBlobURL !== null) { URL.revokeObjectURL(this.#backBlobURL); }
+    this.#backBlobURL = URL.createObjectURL(blob);
     downloadBack.setAttribute(
       "download",
       `${this.#model.typeCodeVIZ}${this.#model.authorityCodeVIZ}` +
       `${this.#model.numberVIZ}-back.png`
     );
-    downloadBack.setAttribute("href", this.#cardBackElement.toDataURL("image/png"));
+    downloadBack.setAttribute("href", this.#backBlobURL);
   }
 
   // Static private methods

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -104,6 +104,8 @@ class CrewCertificateViewModel {
   #backFallback;
   #signatureFallback;
   #signatureGenerator = null;
+  #frontBlobURL = null;
+  #backBlobURL = null;
 
   /** @type { Document } */ #document;
   /** @param { Document } document */

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -1310,6 +1310,9 @@ class CrewCertificateViewModel {
     await this.#renderer.loadCanvasFonts();
     this.cardFrontElement = this.#document.getElementById("cardFront");
     this.cardBackElement = this.#document.getElementById("cardBack");
+    this.#frontFallback = this.#document.getElementById("offscreen-front");
+    this.#backFallback = this.#document.getElementById("offscreen-back");
+    this.#signatureFallback = this.#document.getElementById("offscreen-signature");
     await this.#generateCard();
     const inputFields = [
       "typeCode",

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -100,6 +100,10 @@ class CrewCertificateViewModel {
   });
 
   #inputTimeout = null;
+  #frontFallback;
+  #backFallback;
+  #signatureFallback;
+  #signatureGenerator = null;
 
   /** @type { Document } */ #document;
   /** @param { Document } document */
@@ -1306,9 +1310,6 @@ class CrewCertificateViewModel {
     await this.#renderer.loadCanvasFonts();
     this.cardFrontElement = this.#document.getElementById("cardFront");
     this.cardBackElement = this.#document.getElementById("cardBack");
-    this.#frontFallback = this.#document.getElementById("offscreen-front");
-    this.#backFallback = this.#document.getElementById("offscreen-back");
-    this.#signatureFallback = this.#document.getElementById("offscreen-signature");
     await this.#generateCard();
     const inputFields = [
       "typeCode",

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -405,14 +405,14 @@ class CrewCertificateViewModel {
     this.#signatureTextInput.addEventListener("input", this, false);
     this.#signatureTextInput.addEventListener("change", this, false);
   }
-  async onSignatureTextInputChange() {
+  onSignatureTextInputChange() {
     if (this.#signatureGenerator === null) {
       this.#signatureGenerator = CrewCertificateRenderer.generateNewSignatureFromText(
         this.#signatureFallback
       );
     }
-    await this.#signatureGenerator.next();
-    const signature = await this.#signatureGenerator.next(
+    this.#signatureGenerator.next();
+    const signature = this.#signatureGenerator.next(
       this.#signatureTextInput.value
     );
     if (signature.value.newSignature) {

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -109,12 +109,12 @@ class CrewCertificateViewModel {
   /** @param { Document } document */
   set document(document) { this.#document = document; }
 
-  /** @type { Element } */ #cardFrontElement;
-  /** @param { Element } canvas */
+  /** @type { HTMLCanvasElement } */ #cardFrontElement;
+  /** @param { HTMLCanvasElement } canvas */
   set cardFrontElement(canvas) { this.#cardFrontElement = canvas; }
 
-  /** @type { Element } */ #cardBackElement;
-  /** @param { Element } canvas */
+  /** @type { HTMLCanvasElement } */ #cardBackElement;
+  /** @param { HTMLCanvasElement } canvas */
   set cardBackElement(canvas) { this.#cardBackElement = canvas; }
 
   /** @type { HTMLInputElement } */ #typeCodeInput;
@@ -1396,12 +1396,26 @@ class CrewCertificateViewModel {
 
   // Private methods
   async #generateCardFront() {
-    await this.#renderer.generateCardFront(this.#model, this.#cardFrontElement);
+    const canvas = await this.#renderer.generateCardFront(this.#model, this.#frontFallback);
+    this.#cardFrontElement.width = CrewCertificateRenderer.cutCardArea[0];
+    this.#cardFrontElement.height = CrewCertificateRenderer.cutCardArea[1];
+    ctx = this.#cardFrontElement.getContext("2d");
+    ctx.drawImage(
+      canvas, 16, 16, this.#cardFrontElement.width, this.#cardFrontElement.height,
+      0, 0, this.#cardFrontElement.width, this.#cardFrontElement.height
+    );
     this.#generateDownloadFrontLink();
   }
 
   async #generateCardBack() {
-    await this.#renderer.generateCardBack(this.#model, this.#cardBackElement);
+    const canvas = await this.#renderer.generateCardBack(this.#model, this.#backFallback);
+    this.#cardBackElement.width = CrewCertificateRenderer.cutCardArea[0];
+    this.#cardBackElement.height = CrewCertificateRenderer.cutCardArea[1];
+    ctx = this.#cardBackElement.getContext("2d");
+    ctx.drawImage(
+      canvas, 16, 16, this.#cardBackElement.width, this.#cardBackElement.height,
+      0, 0, this.#cardBackElement.width, this.#cardBackElement.height
+    );
     this.#generateDownloadBackLink();
   }
 

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -1423,11 +1423,9 @@ class CrewCertificateViewModel {
 
   async #generateCard() {
     await Promise.all([
-      this.#renderer.generateCardFront(this.#model, this.#cardFrontElement),
-      this.#renderer.generateCardBack(this.#model, this.#cardBackElement)
+      this.#generateCardFront(),
+      this.#generateCardBack()
     ]);
-    this.#generateDownloadFrontLink();
-    this.#generateDownloadBackLink();
   }
 
   #generateDownloadFrontLink() {

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -1405,29 +1405,6 @@ class CrewCertificateViewModel {
       canvas, 16, 16, this.#cardFrontElement.width, this.#cardFrontElement.height,
       0, 0, this.#cardFrontElement.width, this.#cardFrontElement.height
     );
-    await this.#generateDownloadFrontLink(canvas);
-  }
-
-  async #generateCardBack() {
-    const canvas = await this.#renderer.generateCardBack(this.#model, this.#backFallback);
-    this.#cardBackElement.width = CrewCertificateRenderer.cutCardArea[0];
-    this.#cardBackElement.height = CrewCertificateRenderer.cutCardArea[1];
-    const ctx = this.#cardBackElement.getContext("2d");
-    ctx.drawImage(
-      canvas, 16, 16, this.#cardBackElement.width, this.#cardBackElement.height,
-      0, 0, this.#cardBackElement.width, this.#cardBackElement.height
-    );
-    await this.#generateDownloadBackLink(canvas);
-  }
-
-  async #generateCard() {
-    await Promise.all([
-      this.#generateCardFront(),
-      this.#generateCardBack()
-    ]);
-  }
-
-  async #generateDownloadFrontLink(canvas) {
     const downloadFront = this.#document.getElementById("downloadFront");
     let blob;
     if (typeof OffscreenCanvas === "undefined") {
@@ -1444,7 +1421,15 @@ class CrewCertificateViewModel {
     downloadFront.setAttribute("href", this.#frontBlobURL);
   }
 
-  async #generateDownloadBackLink(canvas) {
+  async #generateCardBack() {
+    const canvas = await this.#renderer.generateCardBack(this.#model, this.#backFallback);
+    this.#cardBackElement.width = CrewCertificateRenderer.cutCardArea[0];
+    this.#cardBackElement.height = CrewCertificateRenderer.cutCardArea[1];
+    const ctx = this.#cardBackElement.getContext("2d");
+    ctx.drawImage(
+      canvas, 16, 16, this.#cardBackElement.width, this.#cardBackElement.height,
+      0, 0, this.#cardBackElement.width, this.#cardBackElement.height
+    );
     const downloadBack = this.#document.getElementById("downloadBack");
     let blob;
     if (typeof OffscreenCanvas === "undefined") {
@@ -1459,6 +1444,13 @@ class CrewCertificateViewModel {
       `${this.#model.numberVIZ}-back.png`
     );
     downloadBack.setAttribute("href", this.#backBlobURL);
+  }
+
+  async #generateCard() {
+    await Promise.all([
+      this.#generateCardFront(),
+      this.#generateCardBack()
+    ]);
   }
 
   // Static private methods

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -415,7 +415,6 @@ class CrewCertificateViewModel {
     const signature = await this.#signatureGenerator.next(
       this.#signatureTextInput.value
     );
-    console.log(signature.value);
     if (signature.value.newSignature) {
       this.#model.signature = signature.value.signature;
       this.#generateCardFront();

--- a/crew-certificate/index.css
+++ b/crew-certificate/index.css
@@ -57,3 +57,7 @@ main {
 .customizationForm h2 {
   grid-column: 1 / 3;
 }
+
+#offscreenCanvases {
+  display: none;
+}

--- a/crew-certificate/index.html
+++ b/crew-certificate/index.html
@@ -209,5 +209,10 @@
         <input id="showGuides" name="showGuides" type="checkbox" />
       </section>
     </main>
+    <div id="offscreenCanvases">
+      <canvas id="offscreen-front"></canvas>
+      <canvas id="offscreen-back"></canvas>
+      <canvas id="offscreen-signature"></canvas>
+    </div>
   </body>
 </html>

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -756,12 +756,18 @@ class CrewLicenseRenderer {
       }
     }
   }
-  static async generateSignatureFromText(signature) {
-    const canvas = new OffscreenCanvas(
-      this.#signatureArea[0],
-      this.#signatureArea[1]
-    );
-    const ctx = canvas.getContext("2d");
+  static async generateSignatureFromText(signature, canvasFallback) {
+    let canvas;
+    let ctx;
+    if (typeof OffscreenCanvas === "undefined") {
+      canvas = canvasFallback;
+      canvas.width = this.#signatureArea[0];
+      canvas.height = this.#signatureArea[1];
+    }
+    else {
+      canvas = new OffscreenCanvas(this.#signatureArea[0], this.#signatureArea[1]);
+    }
+    ctx = canvas.getContext("2d");
     ctx.fillStyle = this.textColor;
     ctx.font = this.#signatureFont;
     ctx.textBaseline = "top";
@@ -770,7 +776,7 @@ class CrewLicenseRenderer {
       signature, Math.max(centerShift, 0), 8,
       this.#signatureArea[0] - 6
     );
-    return await canvas.convertToBlob();
+    return canvas;
   }
 
   // Constructor

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -739,6 +739,23 @@ class CrewLicenseRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
+  static async* generateNewSignatureFromText(canvasFallback) {
+    let oldSignature = "";
+    let signature = "";
+    let canvas;
+
+    while (true) {
+      signature = yield;
+      if (oldSignature === signature) {
+        yield { newSignature: false, signature: canvas };
+      }
+      else {
+        oldSignature = signature;
+        canvas = await this.generateSignatureFromText(signature, canvasFallback);
+        yield { newSignature: true, signature: canvas };
+      }
+    }
+  }
   static async generateSignatureFromText(signature) {
     const canvas = new OffscreenCanvas(
       this.#signatureArea[0],

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -739,7 +739,7 @@ class CrewLicenseRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
-  static async* generateNewSignatureFromText(canvasFallback) {
+  static * generateNewSignatureFromText(canvasFallback) {
     let oldSignature = "";
     let signature = "";
     let canvas;
@@ -751,12 +751,12 @@ class CrewLicenseRenderer {
       }
       else {
         oldSignature = signature;
-        canvas = await this.generateSignatureFromText(signature, canvasFallback);
+        canvas = this.#generateSignatureFromText(signature, canvasFallback);
         yield { newSignature: true, signature: canvas };
       }
     }
   }
-  static async generateSignatureFromText(signature, canvasFallback) {
+  static #generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
     if (typeof OffscreenCanvas === "undefined") {

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -56,7 +56,7 @@ class CrewLicenseRenderer {
   fonts;
 
   // Public Methods
-  /** @param { CrewCertificate } model */
+  /** @param { CrewLicense } model */
   /** @param { HTMLCanvasElement } canvas */
   async generateCardFront(model, canvas) {
     canvas.setAttribute("width", this.constructor.#cardArea[0]);
@@ -320,7 +320,7 @@ class CrewLicenseRenderer {
     }
   }
 
-  /** @param { CrewCertificate } model */
+  /** @param { CrewLicense } model */
   /** @param { HTMLCanvasElement } canvas */
   async generateCardBack(model, canvas) {
     canvas.setAttribute("width", this.constructor.#cardArea[0]);

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -644,6 +644,7 @@ class CrewLicenseRenderer {
 
   // Areas used in card generation (static)
   static #cardArea = [1052, 672];
+  static cutCardArea = [1020, 640];
   static #photoUnderlayArea = [402, 527];
   static #photoArea = [370, 370];
   static #logoUnderlayArea = [434, 93];

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -1301,6 +1301,9 @@ class CrewLicenseViewModel {
     await this.#renderer.loadCanvasFonts();
     this.cardFrontElement = this.#document.getElementById("cardFront");
     this.cardBackElement = this.#document.getElementById("cardBack");
+    this.#frontFallback = this.#document.getElementById("offscreen-front");
+    this.#backFallback = this.#document.getElementById("offscreen-back");
+    this.#signatureFallback = this.#document.getElementById("offscreen-signature");
     await this.#generateCard();
     const inputFields = [
       "typeCode",

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -396,14 +396,14 @@ class CrewLicenseViewModel {
     this.#signatureTextInput.addEventListener("input", this, false);
     this.#signatureTextInput.addEventListener("change", this, false);
   }
-  async onSignatureTextInputChange() {
+  onSignatureTextInputChange() {
     if (this.#signatureGenerator === null) {
       this.#signatureGenerator = CrewLicenseRenderer.generateNewSignatureFromText(
         this.#signatureFallback
       );
     }
-    await this.#signatureGenerator.next();
-    const signature = await this.#signatureGenerator.next(
+    this.#signatureGenerator.next();
+    const signature = this.#signatureGenerator.next(
       this.#signatureTextInput.value
     );
     if (signature.value.newSignature) {

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -102,6 +102,7 @@ class CrewLicenseViewModel {
   #frontFallback;
   #backFallback;
   #signatureFallback;
+  #signatureGenerator = null;
   #frontBlobURL = null;
   #backBlobURL = null;
 
@@ -395,10 +396,17 @@ class CrewLicenseViewModel {
     this.#signatureTextInput.addEventListener("change", this, false);
   }
   async onSignatureTextInputChange() {
-    const blob = await CrewLicenseRenderer.generateSignatureFromText(this.#signatureTextInput.value);
-    const dataURL = await this.constructor.#getFileData(blob);
-    if (this.#model.signature !== dataURL) {
-      this.#model.signature = dataURL;
+    if (this.#signatureGenerator === null) {
+      this.#signatureGenerator = CrewLicenseRenderer.generateNewSignatureFromText(
+        this.#signatureFallback
+      );
+    }
+    await this.#signatureGenerator.next();
+    const signature = await this.#signatureGenerator.next(
+      this.#signatureTextInput.value
+    );
+    if (signature.value.newSignature) {
+      this.#model.signature = signature.value.signature;
       this.#generateCardFront();
     }
   }

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -1387,7 +1387,7 @@ class CrewLicenseViewModel {
 
   // Private methods
   async #generateCardFront() {
-    const canvas = await this.#renderer.generateCardFront(this.#model, this.frontFallback);
+    const canvas = await this.#renderer.generateCardFront(this.#model, this.#frontFallback);
     this.#cardFrontElement.width = CrewLicenseRenderer.cutCardArea[0];
     this.#cardFrontElement.height = CrewLicenseRenderer.cutCardArea[1];
     const ctx = this.#cardFrontElement.getContext("2d");

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -99,6 +99,11 @@ class CrewLicenseViewModel {
   });
 
   #inputTimeout = null;
+  #frontFallback;
+  #backFallback;
+  #signatureFallback;
+  #frontBlobURL = null;
+  #backBlobURL = null;
 
   /** @type { Document } */ #document;
   /** @param { Document } document */

--- a/crew-license/index.css
+++ b/crew-license/index.css
@@ -57,3 +57,7 @@ main {
 .customizationForm h2 {
   grid-column: 1 / 3;
 }
+
+#offscreenCanvases {
+  display: none;
+}

--- a/crew-license/index.html
+++ b/crew-license/index.html
@@ -207,5 +207,10 @@
         <input id="showGuides" name="showGuides" type="checkbox" />
       </section>
     </main>
+    <div id="offscreenCanvases">
+      <canvas id="offscreen-front"></canvas>
+      <canvas id="offscreen-back"></canvas>
+      <canvas id="offscreen-signature"></canvas>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
`CrewLicenseRenderer` and `CrewCertificateRenderer` uses `OffscreenCanvas` to generate the front picture, back picture, and signature (when the signature input is from the form field). Fallback "offscreen" `<canvas>` elements in the HTML, hidden with CSS, are used when `OffscreenCanvas` isn't supported by the browser.

Merging this request closes #2.