### PR TITLE
Removing `static`, setting sizes to ICAO nominal sizes, and more

### DIFF
--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -753,7 +753,7 @@ class CrewCertificateRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
-  static * generateNewSignatureFromText(canvasFallback) {
+  * generateNewSignatureFromText(canvasFallback) {
     let oldSignature = "";
     let signature = "";
     let canvas;
@@ -770,25 +770,25 @@ class CrewCertificateRenderer {
       }
     }
   }
-  static #generateSignatureFromText(signature, canvasFallback) {
+  #generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
     if (typeof OffscreenCanvas === "undefined") {
       canvas = canvasFallback;
-      canvas.setAttribute("width", this.#signatureArea[0]);
-      canvas.setAttribute("height", this.#signatureArea[1]);
+      canvas.width = this.constructor.#signatureArea[0];
+      canvas.height = this.constructor.#signatureArea[1];
     }
     else {
-      canvas = new OffscreenCanvas(this.#signatureArea[0], this.#signatureArea[1]);
+      canvas = new OffscreenCanvas(this.constructor.#signatureArea[0], this.constructor.#signatureArea[1]);
     }
     ctx = canvas.getContext("2d");
     ctx.fillStyle = this.textColor;
-    ctx.font = this.#signatureFont;
+    ctx.font = this.constructor.#signatureFont;
     ctx.textBaseline = "top";
     const centerShift = (canvas.width - ctx.measureText(signature).width) / 2;
     ctx.fillText(
       signature, Math.max(centerShift, 0), 8,
-      this.#signatureArea[0] - 6
+      this.constructor.#signatureArea[0] - 6
     );
     return canvas;
   }

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -714,6 +714,8 @@ class CrewCertificateRenderer {
   }
   static #drawBleedAndSafeLines(ctx) {
     ctx.fillStyle = "#ff0000";
+    ctx.lineWidth = 1;
+    ctx.lineCap = "butt";
     const bleed = 16;
     ctx.beginPath();
     ctx.moveTo(0, bleed);

--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -713,7 +713,7 @@ class CrewCertificateRenderer {
     ctx.restore();
   }
   static #drawBleedAndSafeLines(ctx) {
-    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#ff0000";
     ctx.lineWidth = 1;
     ctx.lineCap = "butt";
     const bleed = 16;
@@ -734,7 +734,7 @@ class CrewCertificateRenderer {
     ctx.lineTo(this.#cardArea[0] - bleed, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
 
-    ctx.fillStyle = "#0000ff";
+    ctx.strokeStyle = "#0000ff";
     const safe = 48;
     ctx.beginPath();
     ctx.moveTo(0, safe);

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -407,7 +407,7 @@ class CrewCertificateViewModel {
   }
   onSignatureTextInputChange() {
     if (this.#signatureGenerator === null) {
-      this.#signatureGenerator = CrewCertificateRenderer.generateNewSignatureFromText(
+      this.#signatureGenerator = this.#renderer.generateNewSignatureFromText(
         this.#signatureFallback
       );
     }

--- a/crew-certificate/index.css
+++ b/crew-certificate/index.css
@@ -27,11 +27,11 @@ main {
 }
 
 #cardFront, #cardBack {
-  max-width: 3.375in;
+  max-width: 85.6mm;
   width: 100%;
   height: auto;
   border: 1px solid #999;
-  border-radius: 16px;
+  border-radius: 3.18mm;
 }
 
 .generated-card {

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -741,7 +741,7 @@ class CrewLicenseRenderer {
     ctx.lineTo(this.#cardArea[0] - safe, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
   }
-  static * generateNewSignatureFromText(canvasFallback) {
+  * generateNewSignatureFromText(canvasFallback) {
     let oldSignature = "";
     let signature = "";
     let canvas;
@@ -758,25 +758,25 @@ class CrewLicenseRenderer {
       }
     }
   }
-  static #generateSignatureFromText(signature, canvasFallback) {
+  #generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
     if (typeof OffscreenCanvas === "undefined") {
       canvas = canvasFallback;
-      canvas.width = this.#signatureArea[0];
-      canvas.height = this.#signatureArea[1];
+      canvas.width = this.constructor.#signatureArea[0];
+      canvas.height = this.constructor.#signatureArea[1];
     }
     else {
-      canvas = new OffscreenCanvas(this.#signatureArea[0], this.#signatureArea[1]);
+      canvas = new OffscreenCanvas(this.constructor.#signatureArea[0], this.constructor.#signatureArea[1]);
     }
     ctx = canvas.getContext("2d");
     ctx.fillStyle = this.textColor;
-    ctx.font = this.#signatureFont;
+    ctx.font = this.constructor.#signatureFont;
     ctx.textBaseline = "top";
     const centerShift = (canvas.width - ctx.measureText(signature).width) / 2;
     ctx.fillText(
       signature, Math.max(centerShift, 0), 8,
-      this.#signatureArea[0] - 6
+      this.constructor.#signatureArea[0] - 6
     );
     return canvas;
   }

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -701,7 +701,7 @@ class CrewLicenseRenderer {
     ctx.restore();
   }
   static #drawBleedAndSafeLines(ctx) {
-    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#ff0000";
     ctx.lineWidth = 1;
     ctx.lineCap = "butt";
     const bleed = 16;
@@ -722,7 +722,7 @@ class CrewLicenseRenderer {
     ctx.lineTo(this.#cardArea[0] - bleed, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
 
-    ctx.fillStyle = "#0000ff";
+    ctx.strokeStyle = "#0000ff";
     const safe = 48;
     ctx.beginPath();
     ctx.moveTo(0, safe);

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -702,6 +702,8 @@ class CrewLicenseRenderer {
   }
   static #drawBleedAndSafeLines(ctx) {
     ctx.fillStyle = "#ff0000";
+    ctx.lineWidth = 1;
+    ctx.lineCap = "butt";
     const bleed = 16;
     ctx.beginPath();
     ctx.moveTo(0, bleed);

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -398,7 +398,7 @@ class CrewLicenseViewModel {
   }
   onSignatureTextInputChange() {
     if (this.#signatureGenerator === null) {
-      this.#signatureGenerator = CrewLicenseRenderer.generateNewSignatureFromText(
+      this.#signatureGenerator = this.#renderer.generateNewSignatureFromText(
         this.#signatureFallback
       );
     }

--- a/crew-license/index.css
+++ b/crew-license/index.css
@@ -27,11 +27,11 @@ main {
 }
 
 #cardFront, #cardBack {
-  max-width: 3.375in;
+  max-width: 85.6mm;
   width: 100%;
   height: auto;
   border: 1px solid #999;
-  border-radius: 16px;
+  border-radius: 3.18mm;
 }
 
 .generated-card {

--- a/events-passport/EventsPassportRenderer.js
+++ b/events-passport/EventsPassportRenderer.js
@@ -845,8 +845,6 @@ class EventsPassportRenderer {
   #generateSignatureFromText(signature, canvasFallback) {
     let canvas;
     let ctx;
-    console.log(`Signature: ${signature}`);
-    console.log(`Canvas Fallback: ${canvasFallback}`);
     if (typeof OffscreenCanvas === "undefined") {
       canvas = canvasFallback;
       canvas.setAttribute("width", this.constructor.#signatureArea[0]);
@@ -856,7 +854,6 @@ class EventsPassportRenderer {
       canvas = new OffscreenCanvas(this.constructor.#signatureArea[0], this.constructor.#signatureArea[1]);
     }
     ctx = canvas.getContext("2d");
-    console.log(`Text Color: ${this.textColor}`);
     ctx.fillStyle = this.textColor;
     ctx.font = this.constructor.#signatureFont;
     ctx.textBaseline = "top";

--- a/events-passport/EventsPassportRenderer.js
+++ b/events-passport/EventsPassportRenderer.js
@@ -847,8 +847,8 @@ class EventsPassportRenderer {
     let ctx;
     if (typeof OffscreenCanvas === "undefined") {
       canvas = canvasFallback;
-      canvas.setAttribute("width", this.constructor.#signatureArea[0]);
-      canvas.setAttribute("height", this.constructor.#signatureArea[1]);
+      canvas.width = this.constructor.#signatureArea[0];
+      canvas.height = this.constructor.#signatureArea[1];
     }
     else {
       canvas = new OffscreenCanvas(this.constructor.#signatureArea[0], this.constructor.#signatureArea[1]);

--- a/id-badge/IDBadgeRenderer.js
+++ b/id-badge/IDBadgeRenderer.js
@@ -583,7 +583,9 @@ class IDBadgeRenderer {
     ctx.restore();
   }
   static #drawBleedAndSafeLines(ctx) {
-    ctx.fillStyle = "#ff0000";
+    ctx.strokeStyle = "#ff0000";
+    ctx.lineWidth = 1;
+    ctx.lineCap = "butt";
     const bleed = 16;
     ctx.beginPath();
     ctx.moveTo(0, bleed);
@@ -602,7 +604,7 @@ class IDBadgeRenderer {
     ctx.lineTo(this.#cardArea[0] - bleed, this.#cardArea[1]);
     ctx.closePath(); ctx.stroke();
 
-    ctx.fillStyle = "#0000ff";
+    ctx.strokeStyle = "#0000ff";
     const safe = 48;
     ctx.beginPath();
     ctx.moveTo(0, safe);

--- a/id-badge/IDBadgeViewModel.js
+++ b/id-badge/IDBadgeViewModel.js
@@ -35,7 +35,7 @@ class IDBadgeViewModel {
     logoUnderlayAlpha: 255,
     logo: "/logos/peets.svg",
     smallLogo: "/smallLogos/alfa-bw.svg",
-    showPunchSlot: true,
+    showPunchSlot: false,
     mrzInQRCode: true,
     showGuides: false,
     additionalElements: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\n",

--- a/id-badge/index.css
+++ b/id-badge/index.css
@@ -27,11 +27,11 @@ main {
 }
 
 #cardFront, #cardBack {
-  max-width: 2.125in;
+  max-width: 53.98mm;
   width: 45%;
   height: auto;
   border: 1px solid #999;
-  border-radius: 16px;
+  border-radius: 3.18mm;
 }
 
 .generated-card {

--- a/id-badge/index.html
+++ b/id-badge/index.html
@@ -111,8 +111,6 @@
         </select>
         <label for="smallLogoFile">Small Authority Logo Image File</label>
         <input id="smallLogoFile" name="smallLogoFile" type="file" />
-        <label for="showPunchSlot">Show Punch Slot</label>
-        <input id="showPunchSlot" name="showPunchSlot" type="checkbox" checked="checked" />
         <h2>Presentation Textual Data</h2>
         <label for="additionalElements">Additional Elements</label>
         <textarea id="additionalElements" name="extra"></textarea>
@@ -154,6 +152,8 @@
         <h2>Debugging Options</h2>
         <label for="showGuides">Show Bleed/Safe Lines</label>
         <input id="showGuides" name="showGuides" type="checkbox" />
+        <label for="showPunchSlot">Show Punch Slot</label>
+        <input id="showPunchSlot" name="showPunchSlot" type="checkbox" />
       </section>
     </main>
     <div id="offscreenCanvases">


### PR DESCRIPTION
These are just a few small changes:

* The signature generation methods should never have been `static`. I've removed the `static` keyword from the two methods in question.
* Sizes of the TD1 cards and the TD3 passport page have been adjusted to be ICAO 9303 nominal dimensions.
* Change 'fillStyle' to 'strokeStyle' and add 'lineWidth' and 'lineCap' to the bleed/safe line generation method so it properly draws on the canvas.
* Use 'width' and 'height' properties instead of `setAttribute()` to make things a bit quicker to read in the future.
* Move 'Show/Hide Punch Slot' to 'Debugging Options' for the ID badge.