### PR TITLE
Harmonize photos between all generators

### DIFF
--- a/crew-certificate/CrewCertificateRenderer.js
+++ b/crew-certificate/CrewCertificateRenderer.js
@@ -616,23 +616,23 @@ class CrewCertificateRenderer {
   // Coordinates used in card generation (static)
   static #mainHeaderX = 1004;
   static #mainHeaderY = [48, 85];
-  static #photoUnderlayXY = [32, 0];
-  static #photoXY = [48, 141];
+  static #photoUnderlayXY = [48, 0];
+  static #photoXY = [72, 141];
   static #stripeXY = [594, 328];
   static #logoUnderlayXY = [871, 282];
   static #numberUnderlayXY = [871, 193];
   static #mrzUnderlayXY = [0, 379];
   static #shortHeaderXY = [886, 167];
   static #qrCodeXY = [594, 48];
-  static #logoFrontXY = [48, 48];
+  static #logoFrontXY = [72, 48];
   static #logoBackXY = [895, 306];
   static #smallLogoXY = [886, 48];
-  static #signatureXY = [48, 543];
+  static #signatureXY = [72, 543];
   static #backNumberXY = [888, 216];
   static #mrzX = 71;
   static #mrzY = [451, 501, 551];
   static #mrzSpacing = 30.35;
-  static #frontColumns = 467;
+  static #frontColumns = 391;
   static #backColumns = 48;
   static #frontRows = [
     141, // name Header
@@ -651,8 +651,8 @@ class CrewCertificateRenderer {
     598  // Date of Expiration Data
   ];
   static #frontRow2Columns = [
-    607, // Nationality Column
-    802  // Date of Birth Column
+    540, // Nationality Column
+    740  // Date of Birth Column
   ];
   static #backRows = [
     48,  // Re-Entry Declaration Header
@@ -667,17 +667,17 @@ class CrewCertificateRenderer {
   // Areas used in card generation (static)
   static #cardArea = [1052, 672];
   static cutCardArea = [1020, 640];
-  static #photoUnderlayArea = [402, 527];
-  static #photoArea = [370, 370];
+  static #photoUnderlayArea = [319, 527];
+  static #photoArea = [271, 362];
   static #stripeArea = [458, 39];
   static #logoUnderlayArea = [181, 46];
   static #numberUnderlayArea = [181, 65];
   static #mrzUnderlayArea = [1052, 293];
   static #qrCodeArea = [256, 256];
-  static #logoArea = [370, 61];
+  static #logoArea = [271, 61];
   static #backLogoArea = [109, 37];
   static #smallLogoArea = [103, 103];
-  static #signatureArea = [370, 81];
+  static #signatureArea = [271, 81];
 
   // Methods used in card generation (static)
   static #generateCanvasImg(img) {

--- a/crew-certificate/CrewCertificateViewModel.js
+++ b/crew-certificate/CrewCertificateViewModel.js
@@ -50,7 +50,7 @@ class CrewCertificateViewModel {
     smallLogo: "/smallLogos/alfa-bw.svg",
     showGuides: false,
     useDigitalSeal: false,
-    fullAuthority: "AIR LINE FURRIES ASSOCIATION, INT'L",
+    fullAuthority: "AIR LINE FURRIES ASSOCIATION, INTERNATIONAL",
     fullDocumentName: "CREWMEMBER CERTIFICATE",
     nameHeader: [
       "NAME",

--- a/crew-license/CrewLicenseRenderer.js
+++ b/crew-license/CrewLicenseRenderer.js
@@ -608,23 +608,23 @@ class CrewLicenseRenderer {
   // Coordinates used in card generation (static)
   static #mainHeaderX = 1004;
   static #mainHeaderY = [48, 85];
-  static #photoUnderlayXY = [32, 0];
-  static #photoXY = [48, 141];
+  static #photoUnderlayXY = [48, 0];
+  static #photoXY = [72, 141];
   static #stripeXY = [594, 328];
   static #logoUnderlayXY = [871, 282];
   static #numberUnderlayXY = [871, 193];
   static #mrzUnderlayXY = [0, 379];
   static #shortHeaderXY = [886, 167];
   static #qrCodeXY = [594, 48];
-  static #logoFrontXY = [48, 48];
+  static #logoFrontXY = [72, 48];
   static #logoBackXY = [895, 306];
   static #smallLogoXY = [886, 48];
-  static #signatureXY = [48, 543];
+  static #signatureXY = [72, 543];
   static #backNumberXY = [888, 216];
   static #mrzX = 71;
   static #mrzY = [451, 501, 551];
   static #mrzSpacing = 30.35;
-  static #frontColumns = 467;
+  static #frontColumns = 391;
   static #backColumns = 48;
   static #frontRows = [
     141, // name Header
@@ -643,8 +643,8 @@ class CrewLicenseRenderer {
     598  // Date of Expiration Data
   ];
   static #frontRow2Columns = [
-    607, // Nationality Column
-    802  // Date of Birth Column
+    540, // Nationality Column
+    740  // Date of Birth Column
   ];
   static #backRows = [
     48,  // Re-Entry Declaration Header
@@ -656,17 +656,17 @@ class CrewLicenseRenderer {
   // Areas used in card generation (static)
   static #cardArea = [1052, 672];
   static cutCardArea = [1020, 640];
-  static #photoUnderlayArea = [402, 527];
-  static #photoArea = [370, 370];
+  static #photoUnderlayArea = [319, 527];
+  static #photoArea = [271, 362];
   static #stripeArea = [458, 39];
   static #logoUnderlayArea = [181, 46];
   static #numberUnderlayArea = [181, 65];
   static #mrzUnderlayArea = [1052, 293];
   static #qrCodeArea = [256, 256];
-  static #logoArea = [370, 61];
+  static #logoArea = [271, 61];
   static #backLogoArea = [109, 37];
   static #smallLogoArea = [103, 103];
-  static #signatureArea = [370, 81];
+  static #signatureArea = [271, 81];
 
   // Methods used in card generation (static)
   static #generateCanvasImg(img) {

--- a/crew-license/CrewLicenseViewModel.js
+++ b/crew-license/CrewLicenseViewModel.js
@@ -18,7 +18,7 @@ class CrewLicenseViewModel {
     nationalityCode: "UTO",
     fullName: "Millefeuille, Alfalfa",
     optionalData: "",
-    subauthority: "Air Line Furries Association, International",
+    subauthority: "COMMITTEE ON ANTHROPOMORPHIC STATISTICS AND CENSUS",
     privilege: "Airline Transport Pilot",
     ratings: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
     limitations: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX\nXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
@@ -51,7 +51,7 @@ class CrewLicenseViewModel {
     smallLogo: "/smallLogos/alfa-bw.svg",
     showGuides: false,
     useDigitalSeal: false,
-    fullAuthority: "AIR LINE FURRIES ASSOCIATION, INT'L",
+    fullAuthority: "AIR LINE FURRIES ASSOCIATION, INTERNATIONAL",
     fullDocumentName: "CREWMEMBER LICENSE",
     nameHeader: [
       "NAME",

--- a/id-badge/IDBadgeRenderer.js
+++ b/id-badge/IDBadgeRenderer.js
@@ -109,15 +109,15 @@ class IDBadgeRenderer {
     );
     this.constructor.#fillAreaWithImg(
       images[1], ctx,
-      this.constructor.#frontColumns[0],
-      this.constructor.#frontRows[3],
+      this.constructor.#photoXY[0],
+      this.constructor.#photoXY[1],
       this.constructor.#photoArea[0],
       this.constructor.#photoArea[1]
     );
     this.constructor.#fitImgInArea(
       images[2], ctx,
-      this.constructor.#frontColumns[0],
-      this.constructor.#frontRows[4],
+      this.constructor.#logoFrontXY[0],
+      this.constructor.#logoFrontXY[1],
       this.constructor.#logoArea[0],
       this.constructor.#logoArea[1]
     );
@@ -492,13 +492,15 @@ class IDBadgeRenderer {
 
   // Coordinates used in card generation (static)
   static #badgeTypeHeaderY = [48, 85];
-  static #photoUnderlayXY = [32, 0];
+  static #photoUnderlayXY = [48, 0];
+  static #photoXY = [72, 113];
   static #stripeXY = [594, 328];
   static #logoUnderlayXY = [871, 282];
   static #numberUnderlayXY = [871, 193];
   static #mrzUnderlayXY = [0, 379];
   static #shortHeaderXY = [886, 167];
   static #backQRCodeXY = [594, 48];
+  static #logoFrontXY = [72, 588]
   static #logoBackXY = [895, 306];
   static #smallLogoXY = [886, 48];
   static #backNumberXY = [888, 216];
@@ -513,14 +515,14 @@ class IDBadgeRenderer {
     263, // Front QR Code
     113, // Photo
     523, // Logo
-    663, // Name Header
-    690, // Name Data
-    746, // Employer Header
-    773, // Employer Data
-    829, // Number Header
-    856, // Number Data
-    912, // Date of Expiration Header
-    939  // Date of Expiration Data
+    704, // Name Header
+    731, // Name Data
+    780, // Employer Header
+    807, // Employer Data
+    856, // Number Header
+    883, // Number Data
+    932, // Date of Expiration Header
+    959  // Date of Expiration Data
   ];
   static #backRows = [
     48,  // Additional Elements Header
@@ -532,15 +534,15 @@ class IDBadgeRenderer {
   // Areas used in card generation (static)
   static #cardArea = [672, 1052];
   static cutCardArea = [640, 1020];
-  static #photoUnderlayArea = [402, 624];
-  static #photoArea = [370, 370];
+  static #photoUnderlayArea = [386, 673];
+  static #photoArea = [338, 451];
   static #stripeArea = [458, 39];
   static #logoUnderlayArea = [181, 46];
   static #numberUnderlayArea = [181, 65];
   static #mrzUnderlayArea = [1052, 293];
   static #frontQRCodeArea = [158, 158];
   static #backQRCodeArea = [256, 256];
-  static #logoArea = [370, 61];
+  static #logoArea = [338, 61];
   static #backLogoArea = [109, 37];
   static #smallLogoArea = [103, 103];
 


### PR DESCRIPTION
The photo areas of the TD1/cards were square, while the passports and visas were rectangle. This harmonizes all the photos in each generator to the same aspect ratio and rearranges the other elements on the card.