### PR TITLE
Perform constraint validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@
 [Air Line Furries Association, International][alfa], provides [generators](https://generator.airlinefurries.com) to create furry-themed travel documents to save as an image or print:
 
 * [Crewmember Certificate](https://generator.airlinefurries.com/crew-certificate/)
+* [Crewmember Identification Badge](https://generator.airlinefurries.com/crew-id/)
 * [Crewmember License](https://generator.airlinefurries.com/crew-license/)
-* [Identification Badge](https://generator.airlinefurries.com/id-badge/)
 * [Events Passport](https://generator.airlinefurries.com/events-passport/)
 * [Events Visa (MRV-A)](https://generator.airlinefurries.com/events-mrva/)
 * [Events Visa (MRV-B)](https://generator.airlinefurries.com/events-mrvb/)

--- a/crew-id/index.html
+++ b/crew-id/index.html
@@ -9,11 +9,11 @@
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <link rel="stylesheet" type="text/css" href="./index.css" />
     <script type="module" src="./index.js"></script>
-    <title>Identification Badge Generator</title>
+    <title>Crewmember Identification Badge Generator</title>
   </head>
   <body>
     <main>
-      <h1>Identification Badge Generator</h1>
+      <h1>Crewmember Identification Badge Generator</h1>
       <div class="generated-card">
         <p><canvas id="cardFront"></canvas> <canvas id="cardBack"></canvas></p>
         <p><a id="downloadFront">Download Front</a> <a id="downloadBack">Download Back</a></p>

--- a/events-seal/index.html
+++ b/events-seal/index.html
@@ -44,8 +44,6 @@
           <option value="F">Female</option>
           <option value="M">Male</option>
         </select>
-        <label for="optionalData">Optional Data</label>
-        <input id="optionalData" name="optionalData" type="text" />
         <h2>Digital Seal Data</h2>
         <label for="issueDate">Date of Issue</label>
         <input id="issueDate" name="issueDate" type="date" />

--- a/index.html
+++ b/index.html
@@ -15,8 +15,8 @@
       <p>Available generators are below:</p>
       <ul>
         <li><a href="/crew-certificate/">Crewmember Certificate</a></li>
+        <li><a href="/crew-id/">Crewmember Identification Badge</a></li>
         <li><a href="/crew-license/">Crewmember License</a></li>
-        <li><a href="/crew-id/">Identification Badge</a></li>
         <li><a href="/events-passport/">Events Passport (MRP/Signature)</a></li>
         <li><a href="/events-mrva/">Events Visa (MRV-A)</a></li>
         <li><a href="/events-mrvb/">Events Visa (MRV-B)</a></li>

--- a/lib/crewcertificate-viewmodel.js
+++ b/lib/crewcertificate-viewmodel.js
@@ -6,6 +6,7 @@ import { CrewCertificateRenderer } from "./crewcertificate-renderer.js";
 import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-signature-from-text.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -117,7 +118,13 @@ export class CrewCertificateViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -133,7 +140,7 @@ export class CrewCertificateViewModel {
    */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute(
@@ -143,7 +150,13 @@ export class CrewCertificateViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -167,7 +180,13 @@ export class CrewCertificateViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -235,7 +254,7 @@ export class CrewCertificateViewModel {
    */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute(
@@ -244,7 +263,13 @@ export class CrewCertificateViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCard();
@@ -290,7 +315,12 @@ export class CrewCertificateViewModel {
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 26
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCardBack();

--- a/lib/crewcertificate-viewmodel.js
+++ b/lib/crewcertificate-viewmodel.js
@@ -286,7 +286,6 @@ export class CrewCertificateViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/crewcertificate-viewmodel.js
+++ b/lib/crewcertificate-viewmodel.js
@@ -7,6 +7,8 @@ import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-sign
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -345,7 +347,10 @@ export class CrewCertificateViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -370,7 +375,12 @@ export class CrewCertificateViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -412,7 +422,13 @@ export class CrewCertificateViewModel {
     this.#employerCodeInput.setAttribute("disabled", "disabled");
   }
   onEmployerCodeInputChange() {
-    if (this.#employerCodeInput.checkValidity() &&
+    this.#employerCodeInput.setCustomValidity(
+      validateHexString(this.#employerCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#employerCodeInput.reportValidity() &&
     this.#model.employerCode !== this.#employerCodeInput.value) {
       this.#model.employerCode = this.#employerCodeInput.value;
       this.#generateCard();
@@ -437,7 +453,13 @@ export class CrewCertificateViewModel {
     this.#occupationCodeInput.setAttribute("disabled", "disabled");
   }
   onOccupationCodeInputChange() {
-    if (this.#occupationCodeInput.checkValidity() &&
+    this.#occupationCodeInput.setCustomValidity(
+      validateHexString(this.#occupationCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#occupationCodeInput.reportValidity() &&
     this.#model.occupationCode !== this.#occupationCodeInput.value) {
       this.#model.occupationCode = this.#occupationCodeInput.value;
       this.#generateCard();

--- a/lib/crewcertificate.js
+++ b/lib/crewcertificate.js
@@ -9,6 +9,7 @@ import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-d
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
 import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `CrewCertificate` describes an ALFA Crewmember Certificate, a TD1-sized
@@ -568,9 +569,10 @@ export class CrewCertificate {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set employerCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of employer code must be 8 characters or less.`
+        `Value set on 'employerCode' has errors: ${isInvalid}`
       );
     }
     const input = [];
@@ -604,10 +606,10 @@ export class CrewCertificate {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set occupationCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of occupation code must be 8 characters or` +
-            "less."
+        `Value set on 'occupationCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/crewid-viewmodel.js
+++ b/lib/crewid-viewmodel.js
@@ -150,7 +150,6 @@ export class CrewIDViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/crewid-viewmodel.js
+++ b/lib/crewid-viewmodel.js
@@ -5,6 +5,7 @@ import { CrewID } from "./crewid.js";
 import { CrewIDRenderer } from "./crewid-renderer.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -69,7 +70,13 @@ export class CrewIDViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -80,7 +87,7 @@ export class CrewIDViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -88,7 +95,13 @@ export class CrewIDViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -107,7 +120,13 @@ export class CrewIDViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -155,7 +174,12 @@ export class CrewIDViewModel {
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 26
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCardBack();

--- a/lib/crewid-viewmodel.js
+++ b/lib/crewid-viewmodel.js
@@ -6,6 +6,8 @@ import { CrewIDRenderer } from "./crewid-renderer.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -211,7 +213,10 @@ export class CrewIDViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -229,7 +234,12 @@ export class CrewIDViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -262,7 +272,13 @@ export class CrewIDViewModel {
     this.#employerCodeInput.setAttribute("disabled", "disabled");
   }
   onEmployerCodeInputChange() {
-    if (this.#employerCodeInput.checkValidity() &&
+    this.#employerCodeInput.setCustomValidity(
+      validateHexString(this.#employerCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#employerCodeInput.reportValidity() &&
     this.#model.employerCode !== this.#employerCodeInput.value) {
       this.#model.employerCode = this.#employerCodeInput.value;
       this.#generateCard();

--- a/lib/crewid.js
+++ b/lib/crewid.js
@@ -8,6 +8,7 @@ import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-s
 import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-digit.js";
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `CrewID` describes an ALFA Crewmember Identification Badge, a TD1-sized
@@ -474,9 +475,10 @@ export class CrewID {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set employerCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of employer code must be 8 characters or less.`
+        `Value set on 'employerCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/crewlicense-viewmodel.js
+++ b/lib/crewlicense-viewmodel.js
@@ -7,6 +7,8 @@ import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-sign
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -269,7 +271,10 @@ export class CrewLicenseViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -287,7 +292,12 @@ export class CrewLicenseViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -320,7 +330,13 @@ export class CrewLicenseViewModel {
     this.#subauthorityCodeInput.setAttribute("disabled", "disabled");
   }
   onSubauthorityCodeInputChange() {
-    if (this.#subauthorityCodeInput.checkValidity() &&
+    this.#subauthorityCodeInput.setCustomValidity(
+      validateHexString(this.#subauthorityCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#subauthorityCodeInput.reportValidity() &&
     this.#model.subauthorityCode !== this.#subauthorityCodeInput.value) {
       this.#model.subauthorityCode = this.#subauthorityCodeInput.value;
       this.#generateCard();
@@ -340,7 +356,13 @@ export class CrewLicenseViewModel {
     this.#privilegeCodeInput.setAttribute("disabled", "disabled");
   }
   onPrivilegeCodeInputChange() {
-    if (this.#privilegeCodeInput.checkValidity() &&
+    this.#privilegeCodeInput.setCustomValidity(
+      validateHexString(this.#privilegeCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#privilegeCodeInput.reportValidity() &&
     this.#model.privilegeCode !== this.#privilegeCodeInput.value) {
       this.#model.privilegeCode = this.#privilegeCodeInput.value;
       this.#generateCard();

--- a/lib/crewlicense-viewmodel.js
+++ b/lib/crewlicense-viewmodel.js
@@ -6,6 +6,7 @@ import { CrewLicenseRenderer } from "./crewlicense-renderer.js";
 import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-signature-from-text.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -78,7 +79,13 @@ export class CrewLicenseViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -89,7 +96,7 @@ export class CrewLicenseViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -97,7 +104,13 @@ export class CrewLicenseViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -116,7 +129,13 @@ export class CrewLicenseViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -163,7 +182,7 @@ export class CrewLicenseViewModel {
   /** @param { HTMLInputElement } input */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute("placeholder", this.#model.nationalityCode);
@@ -171,7 +190,13 @@ export class CrewLicenseViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCard();
@@ -207,7 +232,12 @@ export class CrewLicenseViewModel {
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 26
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCardBack();

--- a/lib/crewlicense-viewmodel.js
+++ b/lib/crewlicense-viewmodel.js
@@ -208,7 +208,6 @@ export class CrewLicenseViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/crewlicense.js
+++ b/lib/crewlicense.js
@@ -8,6 +8,7 @@ import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-d
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
 import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `CrewLicense` describes an ALFA Crewmember License, a TD1-sized
@@ -557,10 +558,10 @@ export class CrewLicense {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set subauthorityCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of (sub)authority code must be 8 characters ` +
-            `or less.`
+        `Value set on 'subauthorityCode' has errors: ${isInvalid}`
       );
     }
     const input = [];
@@ -594,10 +595,10 @@ export class CrewLicense {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set privilegeCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of privilege code must be 8 characters or ` +
-            `less.`
+        `Value set on 'privilegeCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/eventsmrva-viewmodel.js
+++ b/lib/eventsmrva-viewmodel.js
@@ -6,6 +6,7 @@ import { EventsMRVARenderer } from "./eventsmrva-renderer.js";
 import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-signature-from-text.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -73,7 +74,13 @@ export class EventsMRVAViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -84,7 +91,7 @@ export class EventsMRVAViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -92,7 +99,13 @@ export class EventsMRVAViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -167,7 +180,13 @@ export class EventsMRVAViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -237,7 +256,13 @@ export class EventsMRVAViewModel {
     this.#passportNumberInput.addEventListener("change", this, false);
   }
   onPassportNumberInputChange() {
-    if (this.#passportNumberInput.checkValidity() &&
+    this.#passportNumberInput.setCustomValidity(
+      validateMRZString(this.#passportNumberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#passportNumberInput.reportValidity() &&
     this.#model.passportNumber !== this.#passportNumberInput.value) {
       this.#model.passportNumber = this.#passportNumberInput.value;
       this.#generateCard();
@@ -260,7 +285,7 @@ export class EventsMRVAViewModel {
   /** @param { HTMLInputElement } input */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute("placeholder", this.#model.nationalityCode);
@@ -268,7 +293,13 @@ export class EventsMRVAViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCard();
@@ -304,12 +335,17 @@ export class EventsMRVAViewModel {
   set optionalDataInput(input) {
     this.#optionalDataInput = input;
     this.#optionalDataInput.setAttribute("minlength", 0);
-    this.#optionalDataInput.setAttribute("maxlength", 26);
+    this.#optionalDataInput.setAttribute("maxlength", 16);
     this.#optionalDataInput.addEventListener("input", this, false);
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 16
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCard();

--- a/lib/eventsmrva-viewmodel.js
+++ b/lib/eventsmrva-viewmodel.js
@@ -230,7 +230,6 @@ export class EventsMRVAViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/eventsmrva-viewmodel.js
+++ b/lib/eventsmrva-viewmodel.js
@@ -7,6 +7,8 @@ import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-sign
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -377,7 +379,10 @@ export class EventsMRVAViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -395,7 +400,12 @@ export class EventsMRVAViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -491,7 +501,13 @@ export class EventsMRVAViewModel {
     this.#visaTypeCodeInput.setAttribute("disabled", "disabled");
   }
   onVisaTypeCodeInputChange() {
-    if (this.#visaTypeCodeInput.checkValidity() &&
+    this.#visaTypeCodeInput.setCustomValidity(
+      validateHexString(this.#visaTypeCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#visaTypeCodeInput.reportValidity() &&
     this.#model.visaTypeCode !== this.#visaTypeCodeInput.value) {
       this.#model.visaTypeCode = this.#visaTypeCodeInput.value;
       this.#generateCard();

--- a/lib/eventsmrva.js
+++ b/lib/eventsmrva.js
@@ -8,6 +8,7 @@ import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-d
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
 import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `EventsMRVA` describes an ALFA Furry Events Visa in the MRV-A document size
@@ -599,10 +600,10 @@ export class EventsMRVA {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set visaTypeCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of visa type code must be 8 characters or ` +
-            `less.`
+        `Value set on 'visaTypeCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/eventsmrvb-viewmodel.js
+++ b/lib/eventsmrvb-viewmodel.js
@@ -213,7 +213,6 @@ export class EventsMRVBViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/eventsmrvb-viewmodel.js
+++ b/lib/eventsmrvb-viewmodel.js
@@ -6,6 +6,7 @@ import { EventsMRVBRenderer } from "./eventsmrvb-renderer.js";
 import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-signature-from-text.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -72,7 +73,13 @@ export class EventsMRVBViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -83,7 +90,7 @@ export class EventsMRVBViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -91,7 +98,13 @@ export class EventsMRVBViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -166,7 +179,13 @@ export class EventsMRVBViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -220,7 +239,13 @@ export class EventsMRVBViewModel {
     this.#passportNumberInput.addEventListener("change", this, false);
   }
   onPassportNumberInputChange() {
-    if (this.#passportNumberInput.checkValidity() &&
+    this.#passportNumberInput.setCustomValidity(
+      validateMRZString(this.#passportNumberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#passportNumberInput.reportValidity() &&
     this.#model.passportNumber !== this.#passportNumberInput.value) {
       this.#model.passportNumber = this.#passportNumberInput.value;
       this.#generateCard();
@@ -243,7 +268,7 @@ export class EventsMRVBViewModel {
   /** @param { HTMLInputElement } input */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute("placeholder", this.#model.nationalityCode);
@@ -251,7 +276,13 @@ export class EventsMRVBViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCard();
@@ -287,12 +318,17 @@ export class EventsMRVBViewModel {
   set optionalDataInput(input) {
     this.#optionalDataInput = input;
     this.#optionalDataInput.setAttribute("minlength", 0);
-    this.#optionalDataInput.setAttribute("maxlength", 26);
+    this.#optionalDataInput.setAttribute("maxlength", 8);
     this.#optionalDataInput.addEventListener("input", this, false);
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 8
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCard();

--- a/lib/eventsmrvb-viewmodel.js
+++ b/lib/eventsmrvb-viewmodel.js
@@ -7,6 +7,8 @@ import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-sign
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -360,7 +362,10 @@ export class EventsMRVBViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -378,7 +383,12 @@ export class EventsMRVBViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -474,7 +484,13 @@ export class EventsMRVBViewModel {
     this.#visaTypeCodeInput.setAttribute("disabled", "disabled");
   }
   onVisaTypeCodeInputChange() {
-    if (this.#visaTypeCodeInput.checkValidity() &&
+    this.#visaTypeCodeInput.setCustomValidity(
+      validateHexString(this.#visaTypeCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#visaTypeCodeInput.reportValidity() &&
     this.#model.visaTypeCode !== this.#visaTypeCodeInput.value) {
       this.#model.visaTypeCode = this.#visaTypeCodeInput.value;
       this.#generateCard();

--- a/lib/eventsmrvb.js
+++ b/lib/eventsmrvb.js
@@ -8,6 +8,7 @@ import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-d
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
 import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `EventsMRVB` describes an ALFA Furry Events Visa in the MRV-B document size
@@ -602,10 +603,10 @@ export class EventsMRVB {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set visaTypeCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of visa type code must be 8 characters or ` +
-            `less.`
+        `Value set on 'visaTypeCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/eventspassport-viewmodel.js
+++ b/lib/eventspassport-viewmodel.js
@@ -6,6 +6,7 @@ import { EventsPassportRenderer } from "./eventspassport-renderer.js";
 import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-signature-from-text.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -75,7 +76,13 @@ export class EventsPassportViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCardFront();
@@ -86,7 +93,7 @@ export class EventsPassportViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -94,7 +101,13 @@ export class EventsPassportViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCardFront();
@@ -113,7 +126,13 @@ export class EventsPassportViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCardFront();
@@ -143,7 +162,7 @@ export class EventsPassportViewModel {
   /** @param { HTMLInputElement } input */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute("placeholder", this.#model.nationalityCode);
@@ -151,7 +170,13 @@ export class EventsPassportViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCardFront();
@@ -259,12 +284,17 @@ export class EventsPassportViewModel {
   set optionalDataInput(input) {
     this.#optionalDataInput = input;
     this.#optionalDataInput.setAttribute("minlength", 0);
-    this.#optionalDataInput.setAttribute("maxlength", 26);
+    this.#optionalDataInput.setAttribute("maxlength", 14);
     this.#optionalDataInput.addEventListener("input", this, false);
     this.#optionalDataInput.addEventListener("change", this, false);
   }
   onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
+    this.#optionalDataInput.setCustomValidity(
+      validateMRZString(this.#optionalDataInput.value, {
+        maximum: 14
+      })
+    );
+    if (this.#optionalDataInput.reportValidity() &&
     this.#model.optionalData !== this.#optionalDataInput.value) {
       this.#model.optionalData = this.#optionalDataInput.value;
       this.#generateCardFront();

--- a/lib/eventspassport-viewmodel.js
+++ b/lib/eventspassport-viewmodel.js
@@ -144,7 +144,6 @@ export class EventsPassportViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/eventspassport-viewmodel.js
+++ b/lib/eventspassport-viewmodel.js
@@ -7,6 +7,8 @@ import { ifNewGenerateSignatureFromText } from "./utilities/if-new-generate-sign
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -313,7 +315,10 @@ export class EventsPassportViewModel {
     this.#identifierInput.setAttribute("disabled", "disabled");
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -331,7 +336,12 @@ export class EventsPassportViewModel {
     this.#certReferenceInput.setAttribute("disabled", "disabled");
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -364,7 +374,13 @@ export class EventsPassportViewModel {
     this.#subauthorityCodeInput.setAttribute("disabled", "disabled");
   }
   onSubauthorityCodeInputChange() {
-    if (this.#subauthorityCodeInput.checkValidity() &&
+    this.#subauthorityCodeInput.setCustomValidity(
+      validateHexString(this.#subauthorityCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#subauthorityCodeInput.reportValidity() &&
     this.#model.subauthorityCode !== this.#subauthorityCodeInput.value) {
       this.#model.subauthorityCode = this.#subauthorityCodeInput.value;
       this.#generateCard();

--- a/lib/eventspassport.js
+++ b/lib/eventspassport.js
@@ -9,6 +9,7 @@ import { generateMRZCheckDigit } from "./icao9303/utilities/generate-mrz-check-d
 import { c40Encode } from "./icao9303/utilities/c40-encode.js";
 import { c40Decode } from "./icao9303/utilities/c40-decode.js";
 import { getFullYearFromString } from "./icao9303/utilities/get-full-year-from-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
 
 /**
  * `EventsPassport` describes an ALFA Furry Events Passport, a TD3-sized
@@ -523,10 +524,10 @@ export class EventsPassport {
    * @param { string } code - A hex string up to 8 characters long.
    */
   set subauthorityCode(code) {
-    if (code.length > 8) {
+    const isInvalid = validateHexString(code, { minimum: 1, maximum: 8 });
+    if (isInvalid) {
       throw new RangeError(
-        `Length '${code.length}' of (sub)authority code must be 8 characters ` +
-            `or less.`
+        `Value set on 'subauthorityCode' has errors: ${isInvalid}`
       );
     }
     const input = [];

--- a/lib/eventsseal-viewmodel.js
+++ b/lib/eventsseal-viewmodel.js
@@ -220,23 +220,6 @@ export class EventsSealViewModel {
     this.#generateCard();
   }
 
-  /** @type { HTMLInputElement } */ #optionalDataInput;
-  /** @param { HTMLInputElement } input */
-  set optionalDataInput(input) {
-    this.#optionalDataInput = input;
-    this.#optionalDataInput.setAttribute("minlength", 0);
-    this.#optionalDataInput.setAttribute("maxlength", 26);
-    this.#optionalDataInput.addEventListener("input", this, false);
-    this.#optionalDataInput.addEventListener("change", this, false);
-  }
-  onOptionalDataInputChange() {
-    if (this.#optionalDataInput.checkValidity() &&
-    this.#model.optionalData !== this.#optionalDataInput.value) {
-      this.#model.optionalData = this.#optionalDataInput.value;
-      this.#generateCard();
-    }
-  }
-
   /** @type { HTMLInputElement } */ #issueDateInput;
   /** @param { HTMLInputElement } input */
   set issueDateInput(input) {
@@ -564,7 +547,6 @@ export class EventsSealViewModel {
       "nationalityCode",
       "dateOfBirth",
       "genderMarker",
-      "optionalData",
       "headerColor",
       "textColor",
       "frontBackgroundColor",

--- a/lib/eventsseal-viewmodel.js
+++ b/lib/eventsseal-viewmodel.js
@@ -6,6 +6,8 @@ import { EventsSealRenderer } from "./eventsseal-renderer.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
 import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
+import { validateHexString } from "./icao9303/utilities/validate-hex-string.js";
+import { validateIdentifierCode } from "./icao9303/utilities/validate-identifier-code.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -274,7 +276,10 @@ export class EventsSealViewModel {
     this.#identifierInput.addEventListener("change", this, false);
   }
   onIdentifierInputChange() {
-    if (this.#identifierInput.checkValidity() &&
+    this.#identifierInput.setCustomValidity(
+      validateIdentifierCode(this.#identifierInput.value)
+    );
+    if (this.#identifierInput.reportValidity() &&
     this.#model.identifierCode !== this.#identifierInput.value) {
       this.#model.identifierCode = this.#identifierInput.value;
       this.#generateCard();
@@ -291,7 +296,12 @@ export class EventsSealViewModel {
     this.#certReferenceInput.addEventListener("change", this, false);
   }
   onCertReferenceInputChange() {
-    if (this.#certReferenceInput.checkValidity() &&
+    this.#certReferenceInput.setCustomValidity(
+      validateHexString(this.#certReferenceInput.value, {
+        minimum: 1
+      })
+    );
+    if (this.#certReferenceInput.reportValidity() &&
     this.#model.certReference !== this.#certReferenceInput.value) {
       this.#model.certReference = this.#certReferenceInput.value;
       this.#generateCard();
@@ -382,7 +392,13 @@ export class EventsSealViewModel {
     this.#visaTypeCodeInput.addEventListener("change", this, false);
   }
   onVisaTypeCodeInputChange() {
-    if (this.#visaTypeCodeInput.checkValidity() &&
+    this.#visaTypeCodeInput.setCustomValidity(
+      validateHexString(this.#visaTypeCodeInput.value, {
+        minimum: 1,
+        maximum: 8
+      })
+    );
+    if (this.#visaTypeCodeInput.reportValidity() &&
     this.#model.visaTypeCode !== this.#visaTypeCodeInput.value) {
       this.#model.visaTypeCode = this.#visaTypeCodeInput.value;
       this.#generateCard();

--- a/lib/eventsseal-viewmodel.js
+++ b/lib/eventsseal-viewmodel.js
@@ -5,6 +5,7 @@ import { EventsMRVB } from "./eventsmrvb.js";
 import { EventsSealRenderer } from "./eventsseal-renderer.js";
 import { loadFileFromUpload } from "./utilities/load-file-from-upload.js";
 import { signSealUsingRNG } from "./utilities/sign-seal-using-rng.js";
+import { validateMRZString } from "./icao9303/utilities/validate-mrz-string.js";
 
 /**
  * While not a proper "ViewModel", this loads the initial state of the model,
@@ -66,7 +67,13 @@ export class EventsSealViewModel {
     this.#typeCodeInput.addEventListener("change", this, false);
   }
   onTypeCodeInputChange() {
-    if (this.#typeCodeInput.checkValidity() &&
+    this.#typeCodeInput.setCustomValidity(
+      validateMRZString(this.#typeCodeInput.value, {
+        minimum: 1,
+        maximum: 2
+      })
+    );
+    if (this.#typeCodeInput.reportValidity() &&
     this.#model.typeCode !== this.#typeCodeInput.value) {
       this.#model.typeCode = this.#typeCodeInput.value;
       this.#generateCard();
@@ -77,7 +84,7 @@ export class EventsSealViewModel {
   /** @param { HTMLInputElement } input */
   set authorityCodeInput(input) {
     this.#authorityCodeInput = input;
-    this.#authorityCodeInput.setAttribute("minlength", 3);
+    this.#authorityCodeInput.setAttribute("minlength", 1);
     this.#authorityCodeInput.setAttribute("maxlength", 3);
     this.#authorityCodeInput.value = this.#model.authorityCode;
     this.#authorityCodeInput.setAttribute("placeholder", this.#model.authorityCode);
@@ -85,7 +92,13 @@ export class EventsSealViewModel {
     this.#authorityCodeInput.addEventListener("change", this, false);
   }
   onAuthorityCodeInputChange() {
-    if (this.#authorityCodeInput.checkValidity() &&
+    this.#authorityCodeInput.setCustomValidity(
+      validateMRZString(this.#authorityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#authorityCodeInput.reportValidity() &&
     this.#model.authorityCode !== this.#authorityCodeInput.value) {
       this.#model.authorityCode = this.#authorityCodeInput.value;
       this.#generateCard();
@@ -132,7 +145,13 @@ export class EventsSealViewModel {
     this.#numberInput.addEventListener("change", this, false);
   }
   onNumberInputChange() {
-    if (this.#numberInput.checkValidity() &&
+    this.#numberInput.setCustomValidity(
+      validateMRZString(this.#numberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#numberInput.reportValidity() &&
     this.#model.number !== this.#numberInput.value) {
       this.#model.number = this.#numberInput.value;
       this.#generateCard();
@@ -170,7 +189,13 @@ export class EventsSealViewModel {
     this.#passportNumberInput.addEventListener("change", this, false);
   }
   onPassportNumberInputChange() {
-    if (this.#passportNumberInput.checkValidity() &&
+    this.#passportNumberInput.setCustomValidity(
+      validateMRZString(this.#passportNumberInput.value, {
+        minimum: 1,
+        maximum: 9
+      })
+    );
+    if (this.#passportNumberInput.reportValidity() &&
     this.#model.passportNumber !== this.#passportNumberInput.value) {
       this.#model.passportNumber = this.#passportNumberInput.value;
       this.#generateCard();
@@ -181,7 +206,7 @@ export class EventsSealViewModel {
   /** @param { HTMLInputElement } input */
   set nationalityCodeInput(input) {
     this.#nationalityCodeInput = input;
-    this.#nationalityCodeInput.setAttribute("minlength", 3);
+    this.#nationalityCodeInput.setAttribute("minlength", 1);
     this.#nationalityCodeInput.setAttribute("maxlength", 3);
     this.#nationalityCodeInput.value = this.#model.nationalityCode;
     this.#nationalityCodeInput.setAttribute("placeholder", this.#model.nationalityCode);
@@ -189,7 +214,13 @@ export class EventsSealViewModel {
     this.#nationalityCodeInput.addEventListener("change", this, false);
   }
   onNationalityCodeInputChange() {
-    if (this.#nationalityCodeInput.checkValidity() &&
+    this.#nationalityCodeInput.setCustomValidity(
+      validateMRZString(this.#nationalityCodeInput.value, {
+        minimum: 1,
+        maximum: 3
+      })
+    );
+    if (this.#nationalityCodeInput.reportValidity() &&
     this.#model.nationalityCode !== this.#nationalityCodeInput.value) {
       this.#model.nationalityCode = this.#nationalityCodeInput.value;
       this.#generateCard();

--- a/lib/eventsseal-viewmodel.js
+++ b/lib/eventsseal-viewmodel.js
@@ -163,7 +163,6 @@ export class EventsSealViewModel {
   set fullNameInput(input) {
     this.#fullNameInput = input;
     this.#fullNameInput.setAttribute("minlength", 1);
-    this.#fullNameInput.setAttribute("maxlength", 30);
     this.#fullNameInput.value = this.#model.fullName;
     this.#fullNameInput.setAttribute("placeholder", this.#model.fullName);
     this.#fullNameInput.addEventListener("input", this, false);

--- a/lib/icao9303/digitalseal.js
+++ b/lib/icao9303/digitalseal.js
@@ -6,6 +6,7 @@ import { lengthToDERLength } from "./utilities/length-to-der-length.js";
 import { setSignatureZone } from "./utilities/set-signature-zone.js";
 import { validateMRZString } from "./utilities/validate-mrz-string.js"
 import { validateIdentifierCode } from "./utilities/validate-identifier-code.js";
+import { validateHexString } from "./utilities/validate-hex-string.js";
 
 /**
  * Stores common properties and methods for all ICAO 9303 visible digital seals
@@ -103,11 +104,24 @@ export class DigitalSeal {
     this.#identifierCode = value.toUpperCase();
   }
 
+  #certReference;
   /**
    * A hex-string that uniquely identifies a certificate for a given signer.
    * @type { string }
    */
-  certReference;
+  get certReference() { return this.#certReference; }
+  /**
+   * @param { string } value - A hexadecimal string.
+   */
+  set certReference(value) {
+    const isInvalid = validateHexString(value);
+    if (isInvalid) {
+      throw new RangeError(
+        `Value set on 'certReference' has errors: ${isInvalid}`
+      );
+    }
+    this.#certReference = value.toUpperCase();
+  }
 
   #issueDate;
   /**

--- a/lib/icao9303/digitalseal.js
+++ b/lib/icao9303/digitalseal.js
@@ -5,6 +5,7 @@ import { VDS_SIGNATURE_MARKER } from "./utilities/vds-signature-marker.js";
 import { lengthToDERLength } from "./utilities/length-to-der-length.js";
 import { setSignatureZone } from "./utilities/set-signature-zone.js";
 import { validateMRZString } from "./utilities/validate-mrz-string.js"
+import { validateIdentifierCode } from "./utilities/validate-identifier-code.js";
 
 /**
  * Stores common properties and methods for all ICAO 9303 visible digital seals
@@ -93,15 +94,13 @@ export class DigitalSeal {
    *     0-9 and A-Z.
    */
   set identifierCode(value) {
-    if (value.length !== 4) {
+    const isInvalid = validateIdentifierCode(value);
+    if (isInvalid) {
       throw new RangeError(
-        "Signer identifier must be a combination of a two-letter code of the " +
-            "issuing authority and of two alphanumeric characters to identify" +
-            " a signer within the defined issuing authority."
+        `Value set on 'identifierCode' has errors: ${isInvalid}`
       );
-    } else {
-      this.#identifierCode = value;
     }
+    this.#identifierCode = value.toUpperCase();
   }
 
   /**

--- a/lib/icao9303/digitalseal.js
+++ b/lib/icao9303/digitalseal.js
@@ -4,6 +4,7 @@
 import { VDS_SIGNATURE_MARKER } from "./utilities/vds-signature-marker.js";
 import { lengthToDERLength } from "./utilities/length-to-der-length.js";
 import { setSignatureZone } from "./utilities/set-signature-zone.js";
+import { validateMRZString } from "./utilities/validate-mrz-string.js"
 
 /**
  * Stores common properties and methods for all ICAO 9303 visible digital seals
@@ -68,14 +69,16 @@ export class DigitalSeal {
    *     AAA-AAZ, QMA-QZZ, XAA-XZZ, or ZZA-ZZZ.
    */
   set authorityCode(value) {
-    if (value.length > 3) {
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 3
+    });
+    if (isInvalid) {
       throw new RangeError(
-        "Issuing authority must be according to ICAO 9303-3 and be three " +
-            "letters or less."
+        `Value set on 'authorityCode' has errors: ${isInvalid}`
       );
-    } else {
-      this.#authorityCode = value;
     }
+    this.#authorityCode = value.toUpperCase();
   }
 
   #identifierCode;

--- a/lib/icao9303/traveldocument.js
+++ b/lib/icao9303/traveldocument.js
@@ -108,7 +108,7 @@ export class TravelDocument {
       );
     }
     this.#authorityCode = new String(value.toString().toUpperCase());
-    this.#authorityCode.toMRZ = TravelDocument.#doNothingWithThis;
+    this.#authorityCode.toMRZ = TravelDocument.#authorityCodeToMRZ;
     this.#authorityCode.toVIZ = TravelDocument.#doNothingWithThis;
   }
 
@@ -296,6 +296,9 @@ export class TravelDocument {
   }
   static #typeCodeToMRZ = function() {
     return padMRZString(this, 2);
+  }
+  static #authorityCodeToMRZ = function() {
+    return padMRZString(this, 3);
   }
   static #numberToMRZ = function() {
     return padMRZString(this, 9);

--- a/lib/icao9303/traveldocument.js
+++ b/lib/icao9303/traveldocument.js
@@ -4,6 +4,7 @@
 import { DEFAULT_PHOTO, DEFAULT_SIGNATURE_IMAGE } from "./utilities/default-images.js";
 import { dateToVIZ } from "./utilities/date-to-viz.js";
 import { padMRZString } from "./utilities/pad-mrz-string.js";
+import { validateMRZString } from "./utilities/validate-mrz-string.js";
 
 /**
  * Stores common properties and methods for all ICAO 9303 machine-readable
@@ -73,15 +74,16 @@ export class TravelDocument {
    *     A-Z.
    */
   set typeCode(value) {
-    if (value.toString().length > 2) {
-      throw new RangeError(
-        "Document code (typeCode) must be no more than 2 characters."
-      );
-    } else {
-      this.#typeCode = new String(value.toString().toUpperCase());
-      this.#typeCode.toMRZ = TravelDocument.#typeCodeToMRZ;
-      this.#typeCode.toVIZ = TravelDocument.#setThisToUppercase;
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 2
+    });
+    if (isInvalid) {
+      throw new RangeError(`Value set on 'typeCode' has errors: ${isInvalid}`);
     }
+    this.#typeCode = new String(value.toString().toUpperCase());
+    this.#typeCode.toMRZ = TravelDocument.#typeCodeToMRZ;
+    this.#typeCode.toVIZ = TravelDocument.#setThisToUppercase;
   }
 
   #authorityCode;
@@ -96,10 +98,13 @@ export class TravelDocument {
    *     AAA-AAZ, QMA-QZZ, XAA-XZZ, or ZZA-ZZZ.
    */
   set authorityCode(value) {
-    if (value.toString().toUpperCase().length !== 3) {
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 3
+    });
+    if (isInvalid) {
       throw new RangeError(
-        "Issuing state or organization code (authorityCode) must be 3 charact" +
-            "ers."
+        `Value set on 'authorityCode' has errors: ${isInvalid}`
       );
     }
     this.#authorityCode = new String(value.toString().toUpperCase());
@@ -118,15 +123,16 @@ export class TravelDocument {
    *     of the characters 0-9 and A-Z.
    */
   set number(value) {
-    if (value.toString().length > 9) {
-      throw new RangeError(
-        "Document number (number) must be no more than 9 characters."
-      );
-    } else {
-      this.#number = new String(value.toString().toUpperCase());
-      this.#number.toMRZ = TravelDocument.#numberToMRZ;
-      this.#number.toVIZ = TravelDocument.#setThisToUppercase;
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 9
+    });
+    if (isInvalid) {
+      throw new RangeError(`Value set on 'number' has errors: ${isInvalid}`);
     }
+    this.#number = new String(value.toString().toUpperCase());
+    this.#number.toMRZ = TravelDocument.#numberToMRZ;
+    this.#number.toVIZ = TravelDocument.#setThisToUppercase;
   }
 
   #birthDate;
@@ -208,9 +214,13 @@ export class TravelDocument {
    *     AAA-AAZ, QMA-QZZ, XAA-XZZ, or ZZA-ZZZ.
    */
   set nationalityCode(value) {
-    if (value.toString().length !== 3) {
-      throw new RangeError(
-        "Nationality code (nationalityCode) must be 3 characters."
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 3
+    });
+    if (isInvalid) {
+      throw new TypeError(
+        `Value set on 'nationalityCode has errors: ${isInvalid}`
       );
     }
     this.#nationalityCode = new String(value.toString().toUpperCase());
@@ -245,7 +255,15 @@ export class TravelDocument {
    * @param { string } value - Valid characters are from the ranges 0-9, A-Z,
    *     and ' '.
    */
-  set optionalData(value) { this.#optionalData = new String(value.toString()); }
+  set optionalData(value) {
+    const isInvalid = validateMRZString(value);
+    if (isInvalid) {
+      throw new RangeError(
+        `Value set on 'optionalData' has errors: ${isInvalid}`
+      );
+    }
+    this.#optionalData = new String(value.toString());
+  }
 
   /**
    * A path/URL to an image, or an image object, representing a photo of the

--- a/lib/icao9303/traveldocument.js
+++ b/lib/icao9303/traveldocument.js
@@ -108,7 +108,7 @@ export class TravelDocument {
       );
     }
     this.#authorityCode = new String(value.toString().toUpperCase());
-    this.#authorityCode.toMRZ = TravelDocument.#authorityCodeToMRZ;
+    this.#authorityCode.toMRZ = TravelDocument.#nationalityCodeToMRZ;
     this.#authorityCode.toVIZ = TravelDocument.#doNothingWithThis;
   }
 
@@ -224,8 +224,8 @@ export class TravelDocument {
       );
     }
     this.#nationalityCode = new String(value.toString().toUpperCase());
-    this.#nationalityCode.toMRZ = TravelDocument.#setThisToUppercase;
-    this.#nationalityCode.toVIZ = TravelDocument.#setThisToUppercase;
+    this.#nationalityCode.toMRZ = TravelDocument.#nationalityCodeToMRZ;
+    this.#nationalityCode.toVIZ = TravelDocument.#doNothingWithThis;
   }
 
   #fullName;
@@ -297,7 +297,7 @@ export class TravelDocument {
   static #typeCodeToMRZ = function() {
     return padMRZString(this, 2);
   }
-  static #authorityCodeToMRZ = function() {
+  static #nationalityCodeToMRZ = function() {
     return padMRZString(this, 3);
   }
   static #numberToMRZ = function() {

--- a/lib/icao9303/traveldocument.js
+++ b/lib/icao9303/traveldocument.js
@@ -295,13 +295,13 @@ export class TravelDocument {
     return dateToVIZ(this);
   }
   static #typeCodeToMRZ = function() {
-    return padMRZString(this, 2);
+    return padMRZString(this.replace(/ /gi, "<"), 2);
   }
   static #nationalityCodeToMRZ = function() {
-    return padMRZString(this, 3);
+    return padMRZString(this.replace(/ /gi, "<"), 3);
   }
   static #numberToMRZ = function() {
-    return padMRZString(this, 9);
+    return padMRZString(this.replace(/ /gi, "<"), 9);
   }
   static #genderMarkerToMRZ = function() {
     return `${this}` === "X" ? "<" : this;

--- a/lib/icao9303/utilities/full-name-mrz.js
+++ b/lib/icao9303/utilities/full-name-mrz.js
@@ -18,7 +18,7 @@ import { padMRZString } from "./pad-mrz-string.js";
  * fullNameMRZ("Millefeuille, Alfalfa", 30);
  */
 export function fullNameMRZ(name, length) {
-  const splitName = name.split("/");
+  const splitName = name.split("/ ");
   const NORMALIZED_NAME =
       normalizeMRZString(splitName[splitName.length - 1].replace(", ","<<"));
   if (NORMALIZED_NAME.length > length) {

--- a/lib/icao9303/utilities/full-name-mrz.js
+++ b/lib/icao9303/utilities/full-name-mrz.js
@@ -18,8 +18,9 @@ import { padMRZString } from "./pad-mrz-string.js";
  * fullNameMRZ("Millefeuille, Alfalfa", 30);
  */
 export function fullNameMRZ(name, length) {
+  const splitName = name.split("/");
   const NORMALIZED_NAME =
-      normalizeMRZString(name.replace(", ","<<"));
+      normalizeMRZString(splitName[splitName.length - 1].replace(", ","<<"));
   if (NORMALIZED_NAME.length > length) {
     console.warn(
       `Name (fullName) is longer than ${length} and will be truncated.`

--- a/lib/icao9303/utilities/stringify-validation-array.js
+++ b/lib/icao9303/utilities/stringify-validation-array.js
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Given a string[] from a validation function, stringify the errors into a
+ *     human-readable result with punctuation and capitalization.
+ * @param { string[] } errors
+ */
+export function stringifyValidationArray(errors) {
+  if (errors.length === 0) {
+    return "";
+  }
+  let output = "";
+  errors.forEach((error, i) => {
+    if (i === 0) {
+      output += error[0].toUpperCase();
+      output += error.slice(1);
+      output += (i + 1) === errors.length ? "." : "; ";
+    } else {
+      output += (i + 1) === errors.length ? "and " : "";
+      output += error;
+      output += (i + 1) === errors.length ? "." : "; ";
+    }
+  });
+  return output;
+}

--- a/lib/icao9303/utilities/validate-hex-string.js
+++ b/lib/icao9303/utilities/validate-hex-string.js
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+import { stringifyValidationArray } from "./stringify-validation-array.js";
+
+/**
+ * Check to see if a string is a hexadecimal string.
+ * @param { string } string - The string to validate
+ * @param { Object } [opt] - An options object.
+ * @param { number } [opt.minimum] - The minimum length of the string.
+ * @param { number } [opt.maximum] - The maximum length of the string.
+ * @returns { string } An empty string if it meets validation or a string
+ *     which describes why the string isn't valid.
+ */
+export function validateHexString(string, opt) {
+  const errors = [];
+  const minimum = opt?.minimum ?? null;
+  const maximum = opt?.maximum ?? null;
+  const invalidCharacters = /[^0-9A-F]/i;
+
+  if (minimum !== null) {
+    if (string.length < minimum) {
+      errors.push(
+        `length must be at least ${minimum} character${minimum === 1 ? "":"s"}`
+      );
+    }
+  }
+  if (maximum !== null) {
+    if (string.length > maximum) {
+      errors.push(
+        `length must be less than ${maximum} character${maximum === 1 ? "":"s"}`
+      );
+    }
+  }
+  if (invalidCharacters.test(string)) {
+    errors.push("must only use the characters 0-9 or A-F");
+  }
+
+  return stringifyValidationArray(errors);
+}

--- a/lib/icao9303/utilities/validate-identifier-code.js
+++ b/lib/icao9303/utilities/validate-identifier-code.js
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { stringifyValidationArray } from "./stringify-validation-array.js";
+
 /**
  * Given a string, check to see if it meets the requirements of an identifier
  *     code of a visible digital seal (VDS).
@@ -31,21 +33,5 @@ export function validateIdentifierCode(string) {
     );
   }
 
-  if (errors.length === 0) {
-    return "";
-  } else {
-    let output = "";
-    errors.forEach((error, i) => {
-      if (i === 0) {
-        output += error[0].toUpperCase();
-        output += error.slice(1);
-        output += (i + 1) === errors.length ? "." : "; ";
-      } else {
-        output += (i + 1) === errors.length ? "and " : "";
-        output += error;
-        output += (i + 1) === errors.length ? "." : "; ";
-      }
-    });
-    return output;
-  }
+  return stringifyValidationArray(errors);
 }

--- a/lib/icao9303/utilities/validate-identifier-code.js
+++ b/lib/icao9303/utilities/validate-identifier-code.js
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Given a string, check to see if it meets the requirements of an identifier
+ *     code of a visible digital seal (VDS).
+ * @param { string } string
+ * @returns { string } An empty string if it meets validation, or a string
+ *     which describes why the string isn't valid.
+ */
+export function validateIdentifierCode(string) {
+  const errors = [];
+  const countryCodeInvalid = /[^A-Z]/i;
+  const signerCodeInvalid = /[^A-Z0-9]/i;
+  const countryCode = string.slice(0, 2);
+  const signerCode = string.slice(2);
+
+  if (string.length !== 4) {
+    errors.push(
+      "full identifier code must be 4 characters long"
+    );
+  }
+  if (countryCodeInvalid.test(countryCode)) {
+    errors.push(
+      "country code (characters 1-2) must use only characters A-Z"
+    );
+  }
+  if (signerCodeInvalid.test(signerCode)) {
+    errors.push(
+      "signer code (characters 3-4) must use only characters A-Z or 0-9"
+    );
+  }
+
+  if (errors.length === 0) {
+    return "";
+  } else {
+    let output = "";
+    errors.forEach((error, i) => {
+      if (i === 0) {
+        output += error[0].toUpperCase();
+        output += error.slice(1);
+        output += (i + 1) === errors.length ? "." : "; ";
+      } else {
+        output += (i + 1) === errors.length ? "and " : "";
+        output += error;
+        output += (i + 1) === errors.length ? "." : "; ";
+      }
+    });
+    return output;
+  }
+}

--- a/lib/icao9303/utilities/validate-mrz-string.js
+++ b/lib/icao9303/utilities/validate-mrz-string.js
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+/**
+ * Given a string, checks to see if it meets the requirements to be used in a
+ *     document's machine-readable zone (MRZ).
+ * @param { string } string - The string to validate.
+ * @param { Object } [opt] - An options object.
+ * @param { number } [opt.minimum] - The minimum length of the string.
+ * @param { number } [opt.maximum] - The maximum length of the string.
+ * @returns { string } An empty string if it meets validation, or a string
+ *     which describes why the string isn't valid, which may be: it doesn't meet
+ *     the set minimum or maximum ranges, or it uses a character that's invalid
+ *     in the MRZ.
+ */
+export function validateMRZString(string, opt) {
+  const errors = [];
+  const minimum = opt?.minimum ?? null;
+  const maximum = opt?.maximum ?? null;
+  const invalidCharacters = /[^A-Z0-9<\s]/i;
+
+  if (minimum !== null) {
+    if (string.length < minimum) {
+      errors.push(`length must be at least ${minimum} characters`);
+    }
+  }
+  if (maximum !== null) {
+    if (string.length > maximum) {
+      errors.push(`length must not be more than ${maximum} characters`);
+    }
+  }
+  if (invalidCharacters.test(string)) {
+    errors.push("must only use the characters A-Z, 0-9, ' ', or '<'");
+  }
+
+  if (errors.length === 0) {
+    return "";
+  } else {
+    let output = "";
+    errors.forEach((error, i) => {
+      if (i === 0) {
+        output += error[0].toUpperCase();
+        output += error.slice(1);
+        output += (i + 1) === errors.length ? "." : "; ";
+      } else {
+        output += (i + 1) === errors.length ? "and " : "";
+        output += error;
+        output += (i + 1) === errors.length ? "." : "; ";
+      }
+    });
+    return output;
+  }
+}

--- a/lib/icao9303/utilities/validate-mrz-string.js
+++ b/lib/icao9303/utilities/validate-mrz-string.js
@@ -21,12 +21,16 @@ export function validateMRZString(string, opt) {
 
   if (minimum !== null) {
     if (string.length < minimum) {
-      errors.push(`length must be at least ${minimum} characters`);
+      errors.push(
+        `length must be at least ${minimum} character${minimum === 1 ? "":"s"}`
+      );
     }
   }
   if (maximum !== null) {
     if (string.length > maximum) {
-      errors.push(`length must not be more than ${maximum} characters`);
+      errors.push(
+        `length must be less than ${maximum} character${maximum === 1 ? "":"s"}`
+      );
     }
   }
   if (invalidCharacters.test(string)) {

--- a/lib/icao9303/utilities/validate-mrz-string.js
+++ b/lib/icao9303/utilities/validate-mrz-string.js
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 /**
- * Given a string, checks to see if it meets the requirements to be used in a
+ * Given a string, check to see if it meets the requirements to be used in a
  *     document's machine-readable zone (MRZ).
  * @param { string } string - The string to validate.
  * @param { Object } [opt] - An options object.

--- a/lib/icao9303/utilities/validate-mrz-string.js
+++ b/lib/icao9303/utilities/validate-mrz-string.js
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Don Geronimo <https://sentamal.in/>
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+import { stringifyValidationArray } from "./stringify-validation-array.js";
+
 /**
  * Given a string, check to see if it meets the requirements to be used in a
  *     document's machine-readable zone (MRZ).
@@ -37,21 +39,5 @@ export function validateMRZString(string, opt) {
     errors.push("must only use the characters A-Z, 0-9, ' ', or '<'");
   }
 
-  if (errors.length === 0) {
-    return "";
-  } else {
-    let output = "";
-    errors.forEach((error, i) => {
-      if (i === 0) {
-        output += error[0].toUpperCase();
-        output += error.slice(1);
-        output += (i + 1) === errors.length ? "." : "; ";
-      } else {
-        output += (i + 1) === errors.length ? "and " : "";
-        output += error;
-        output += (i + 1) === errors.length ? "." : "; ";
-      }
-    });
-    return output;
-  }
+  return stringifyValidationArray(errors);
 }

--- a/lib/icao9303/visadocument.js
+++ b/lib/icao9303/visadocument.js
@@ -3,6 +3,7 @@
 
 import { dateToVIZ } from "./utilities/date-to-viz.js";
 import { padMRZString } from "./utilities/pad-mrz-string.js";
+import { validateMRZString } from "./utilities/validate-mrz-string.js";
 
 /**
  * Stores properties specific to machine-readable visa documents.
@@ -127,15 +128,18 @@ export class VisaDocument {
    *     of the characters 0-9 and A-Z.
    */
   set passportNumber(value) {
-    if (value.toString().length > 9) {
+    const isInvalid = validateMRZString(value, {
+      minimum: 1,
+      maximum: 9
+    });
+    if (isInvalid) {
       throw new RangeError(
-        "Passport number (passportNumber) must be no more than 9 characters."
+        `Value set on 'passportNumber' has errors: ${isInvalid}`
       );
-    } else {
-      this.#passportNumber = new String(value.toString());
-      this.#passportNumber.toMRZ = VisaDocument.#passportNumberToMRZ;
-      this.#passportNumber.toVIZ = VisaDocument.#setThisToUppercase;
     }
+    this.#passportNumber = new String(value.toString());
+    this.#passportNumber.toMRZ = VisaDocument.#passportNumberToMRZ;
+    this.#passportNumber.toVIZ = VisaDocument.#setThisToUppercase;
   }
 
   /**
@@ -150,7 +154,7 @@ export class VisaDocument {
     return this.toUpperCase();
   }
   static #passportNumberToMRZ = function() {
-    return padMRZString(this, 9);
+    return padMRZString(this.replace(/ /gi, "<"), 9);
   }
   static #validFromToVIZ = function() {
     return dateToVIZ(this);


### PR DESCRIPTION
Use constraint validation to validate form fields and values set on properties when the value is a string. These are done with three functions created in `utilities`:

* `validateHexString(string, opt)`
* `validateMRZString(string, opt)`
* `validateIdentifierCode(string)`

Utilizing functions allow them to be imported and allow the same constraints to be used on front-end forms and when using string values on `set` accessors.

Additionally, `fullNameMRZ()` was modified to allow splitting a name in a non-Latin character set like Japanese or Arabic from its Latin transcription/transliteration. When typing out a name, a '/ ' separates the non-Latin character set name from the Latin transcription/transliteration.